### PR TITLE
Update the gulp build to include necessary slick-carousel less files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -55,6 +55,7 @@
     "angular": "^1.6.0",
     "angular-animate": "^1.6.0",
     "angular-resource": "^1.6.0",
-    "angular-cookies": "^1.6.0"
+    "angular-cookies": "^1.6.0",
+    "slick-carousel": "^1.6.0"
   }
 }

--- a/gulp/build/styles.js
+++ b/gulp/build/styles.js
@@ -22,6 +22,13 @@ function StylesFunction() {
             mainBowerFiles({
                 filter: '**/*.less',
                 overrides: {
+                    'slick-carousel': {
+                        main: [
+                            "slick/slick.js",
+                            "slick/slick.less",
+                            "slick/slick-theme.less"
+                        ]
+                    },
                     'jasny-bootstrap': {
                         main: [
                             "./dist/js/jasny-bootstrap.js",

--- a/src/app/styles/main.less
+++ b/src/app/styles/main.less
@@ -5,6 +5,7 @@
 @import 'layout/glob';
 @import 'pages/glob';
 @import 'utils/glob';
+@import 'vendors/glob';
 
 //Theme styles are imported last for proper overwriting
 @import 'theme/glob';

--- a/src/app/styles/vendors/_slick-carousel.less
+++ b/src/app/styles/vendors/_slick-carousel.less
@@ -1,0 +1,17 @@
+@slick-font-path: "nothing";
+@slick-font-family: "FontAwesome";
+@slick-loader-path: "./";
+@slick-arrow-color: @brand-primary;
+@slick-dot-color: black;
+@slick-dot-color-active: @slick-dot-color;
+@slick-prev-character: @fa-var-arrow-left;
+@slick-next-character: @fa-var-arrow-right;
+@slick-dot-character: "•";
+@slick-dot-size: 6px;
+@slick-opacity-default: 0.75;
+@slick-opacity-on-hover: 1;
+@slick-opacity-not-active: 0.25;
+// .slick-slider.multiple-items.has-arrows {
+//    margin-left: 15px;
+//    margin-right: 15px;
+//  }

--- a/src/app/styles/vendors/glob.less
+++ b/src/app/styles/vendors/glob.less
@@ -1,0 +1,1 @@
+@import '_slick-carousel';


### PR DESCRIPTION
* Update the gulp build.
* Add vendors directory with _slick-carousel.less module for overriding default styles.
* Update bower.json to pull in slick-carousel library.

DCR-16